### PR TITLE
Fix autobump when same artifact used for multiple platforms

### DIFF
--- a/bump/bump.go
+++ b/bump/bump.go
@@ -110,7 +110,7 @@ var (
 func isBumpHunk(hunk []byte, vA, vB string) (bool, error) {
 	lines := bytes.Split(hunk, []byte{'\n'})
 
-	var oldURLs []string
+	oldURLs := make(map[string]bool)
 	newURLs := make(map[string]bool)
 
 	for lineno, line := range lines {
@@ -127,7 +127,7 @@ func isBumpHunk(hunk []byte, vA, vB string) (bool, error) {
 			if len(urlA) > 1 {
 				// add old url to the list
 				url := trimURLMatch(urlA[len(urlA)-1])
-				oldURLs = append(oldURLs, url)
+				oldURLs[url] = true
 			}
 
 			urlB := newURLDiffLine.FindSubmatch(line)
@@ -141,7 +141,7 @@ func isBumpHunk(hunk []byte, vA, vB string) (bool, error) {
 		return false, fmt.Errorf("change on line `%d` does not seem like a version bump: [`%s`]", lineno, string(line))
 	}
 
-	for _, oldURL := range oldURLs {
+	for oldURL := range oldURLs {
 		ua := oldURL
 
 		// sometimes people don't include v* prefix in file names

--- a/bump/bump_test.go
+++ b/bump/bump_test.go
@@ -19,6 +19,8 @@ func TestIsBumpPatch(t *testing.T) {
 			want: true},
 		{tc: SinglePluginBumpTrivial,
 			want: true},
+		{tc: SinglePluginSameArtifactMultipleOS,
+			want: true},
 	}
 	for _, c := range cases {
 		t.Run(c.tc.name, func(tt *testing.T) {
@@ -28,6 +30,29 @@ func TestIsBumpPatch(t *testing.T) {
 			}
 			if got != c.want {
 				tt.Fatalf("got:%v want:%v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestIsValidBump(t *testing.T) {
+	cases := []struct {
+		tc          testCase
+		expectError bool
+	}{
+		{tc: SinglePluginSameArtifactMultipleOS},
+		{tc: SinglePluginBumpTrivial},
+		{tc: SinglePluginBumpNonTrivial, expectError: true},
+	}
+	for _, c := range cases {
+		t.Run(c.tc.name, func(tt *testing.T) {
+			err := IsValidBump(downloadPatch(tt, c.tc.patchURL))
+			if !c.expectError && err != nil {
+				tt.Fatalf("got unexpected error %v", err)
+			}
+
+			if c.expectError && err == nil {
+				tt.Fatalf("expected error, got none")
 			}
 		})
 	}

--- a/bump/testcases_test.go
+++ b/bump/testcases_test.go
@@ -27,6 +27,9 @@ var (
 	SinglePluginBumpTrivial = testCase{
 		name:     "version bump and straightforward",
 		patchURL: "https://github.com/kubernetes-sigs/krew-index/pull/1808.diff"}
+	SinglePluginSameArtifactMultipleOS = testCase{
+		name:     "single plugin with same artifact for multiple os",
+		patchURL: "https://github.com/kubernetes-sigs/krew-index/pull/2640.diff"}
 )
 
 func downloadPatch(t *testing.T, url string) []byte {


### PR DESCRIPTION
it was happening because this plugin has same artifact for `darwin` and `linux`. 

the old urls slice was getting appended with duplicate urls and thus was causing invalid rejection of version bump.